### PR TITLE
Update deprecated import

### DIFF
--- a/quiffen/core/transactions.py
+++ b/quiffen/core/transactions.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from datetime import datetime
-import collections
+import collections.abc
 
 from decimal import Decimal
 
@@ -8,7 +8,7 @@ from quiffen.utils import parse_date, create_categories
 from quiffen.core.categories_classes import Category, Class
 
 
-class TransactionList(collections.MutableSequence, ABC):
+class TransactionList(collections.abc.MutableSequence, ABC):
     """
     A class to store Transaction-type objects only in an ordered list.
 


### PR DESCRIPTION
<string>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working