### PR TITLE
Fixed bug with export of CCard charge transaction to qif - specifically one with splits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/quiffen/core/qif.py
+++ b/quiffen/core/qif.py
@@ -498,14 +498,14 @@ QIF:
                                     if split.date:
                                         qif_data += f'D{split.date.strftime(date_format)}\n'
 
+                                    if split.memo:
+                                        qif_data += f'E{split.memo}\n'
+                                        
                                     if split.amount is not None:
                                         qif_data += f'${split.amount}\n'
 
                                     if split.percent is not None:
                                         qif_data += f'%{split.percent}\n'
-
-                                    if split.memo:
-                                        qif_data += f'E{split.memo}\n'
 
                                     if split.cleared:
                                         qif_data += f'C{split.cleared}\n'

--- a/quiffen/core/transactions.py
+++ b/quiffen/core/transactions.py
@@ -638,7 +638,7 @@ class Transaction:
                                       if split.percent]) + new_split.percent > 100:
             raise ValueError('Percentage sum of splits cannot add up to more than 100%')
 
-        if new_split.amount and sum([split.amount for split in self._splits if split.amount]) > self._amount:
+        if new_split.amount and sum([split.amount for split in self._splits if split.amount]) > abs(self._amount):
             raise ValueError('Splits amounts cannot sum to more than Transaction amount')
 
         self._splits.append(new_split)


### PR DESCRIPTION
Tested with Quicken Home, Business & Rental Property R37.66 Build 27.1.37.66

Identified and resolved the following issues:
1. For a CCard charge transaction that has splits, split values show up as positive whereas charge value is negative. This was causing a ValueError 'Splits amounts cannot sum to more than Transaction amount'  to be raised. Made required changes in quiffen/core/transactions.py

2. The latest version of quick is not loading memo's correctly for splits from the exported qif file. quicken seems to be sensitive to the order in which the entries appear in qif file. Requires S -> E ->$ instead of S -> $ -> E. In the latter case the Memo is applied to the next entry. Refer changes in quiffen/core/qif.py