### PR TITLE
Robustly handle memo parsing (bug fix) and add basic build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build
+/dist
+/*.egg-info

--- a/makefile
+++ b/makefile
@@ -1,0 +1,22 @@
+PKG_NAME = 	quiffen
+PY_BIN = 	python
+
+.PHONY:		test
+test:
+		( cd tests ; python -m unittest )
+
+.PHONY:		wheel
+wheel:
+		$(PY_BIN) setup.py bdist_wheel --universal
+
+.PHONY:		install
+install:	wheel
+		$(PY_BIN) -m pip install --force-reinstall dist/$(PKG_NAME)-*.whl
+
+.PHONY:		reinstall
+reinstall:	clean install
+
+.PHONY:		clean
+clean:
+		find . -type d -name __pycache__ -prune -exec rm -r {} \;
+		rm -fr build dist *.egg-info test2.qif

--- a/quiffen/core/transactions.py
+++ b/quiffen/core/transactions.py
@@ -1,11 +1,14 @@
 import collections.abc
 import decimal
 from abc import ABC
+import logging
 from datetime import datetime
 from decimal import Decimal
 
 from quiffen.core.categories_classes import Category, Class
 from quiffen.utils import parse_date, create_categories
+
+logger = logging.getLogger(__name__)
 
 
 class TransactionList(collections.abc.MutableSequence, ABC):
@@ -481,6 +484,9 @@ class Transaction:
                 else:
                     current_split.date = transaction_date
             elif line_code == 'E':
+                if current_split is None:
+                    logger.warning(f"no split yet given for memo '{field_info}'--skipping")
+                    continue
                 current_split.memo = field_info
             elif line_code == '$' or line_code == '£':
                 current_split.amount = Decimal(round(float(field_info.replace(',', '')), 2))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+    name='quiffen',
+    version='1.0',
+    description='Quiffen is a Python package for parsing QIF (Quicken Interchange Format) files.',
+    author='Isaac Harris-Holt',
+    author_email='isaac@harris-holt.com',
+    url='https://github.com/isaacharrisholt/quiffen',
+    packages=['quiffen', 'quiffen.core'],
+)


### PR DESCRIPTION
This pull request does two things:

* robustly handle missing 'S' section when parssing memos: create wheel, clean, install
* add build automation with make and gitignores on derived objects (such as the build directory etc)
