### PR TITLE
Security class - inspired heavily by Investment class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .venv
 .idea
 **/__pycache__
+tests/testqifs/example-security-list.write.qif

--- a/quiffen/core/security.py
+++ b/quiffen/core/security.py
@@ -1,0 +1,180 @@
+class Security:
+    """
+    A class used to represent a security.
+
+    Behaves like the Investment class.
+    """
+
+    def __init__(self,
+                name: str = None,
+                symbol: str = None,
+                type: str = None,
+                goal: str = None,
+                line_number: int = None
+                ):
+        """Initialise an instance of the Investment class.
+
+        Parameters
+        ----------
+        name : str, default=None
+            The name of the security
+        symbol : str, default=None
+            The symbol to be used for the security
+        type : str, default=None
+            The type of the security (e.g., share, bond, ...)
+        goal : str, default=None
+            Purpose of holding the security
+        line_number : int, default=None
+            The line number of the investment in the QIF file.
+        """
+        self._name = name
+        self._symbol = symbol
+        self._type = type
+        self._goal = goal
+        self._line_number = line_number
+
+    def __eq__(self, other):
+        if not isinstance(other, Security):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __str__(self):
+        properties = ''
+        for (object_property, value) in self.__dict__.items():
+            if value:
+                properties += f'\n    {object_property.strip("_").replace("_", " ").title()}: {value}'
+
+        return 'Security:' + properties
+
+    def __repr__(self):
+        properties = ''
+        for (object_property, value) in self.__dict__.items():
+            if value is not None:
+                properties += f'{object_property.strip("_")}={repr(value)}, '
+
+        properties = properties.strip(', ')
+        return f'Security({properties})'
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, new_name):
+        self._date = str(new_name)
+
+    @property
+    def symbol(self):
+        return self._symbol
+
+    @symbol.setter
+    def symbol(self, new_symbol):
+        self._symbol = str(new_symbol)
+
+    @property
+    def goal(self):
+        return self._goal
+
+    @goal.setter
+    def goal(self, new_goal):
+        self._goal = str(new_goal)
+
+    @property
+    def type(self):
+        return self._type
+
+    @type.setter
+    def type(self, new_type):
+        self._type = str(new_type)
+
+    @property
+    def line_number(self):
+        return self._line_number
+
+    @classmethod
+    def from_list(cls, lst, line_number=None):
+        """Return a class instance from a list of QIF strings.
+
+        Parameters
+        ----------
+        lst : list of str
+            List of strings containing QIF information about the security.
+        line_number : int, default=None
+            The line number of the header line of the security in the QIF file.
+
+        Returns
+        -------
+        Security
+            A Security object created from the QIF strings.
+        """
+        kwargs = {}
+        for field in lst:
+            field = field.replace('\n', '')
+
+            if not field:
+                continue
+            line_code = field[0]
+
+            try:
+                field_info = field[1:]
+            except KeyError:
+                field_info = ''
+
+            # Check the QIF line code for security-related operations, then append to kwargs.
+            if line_code == 'N':
+                kwargs['name'] = field_info
+            elif line_code == 'S':
+                kwargs['symbol'] = field_info
+            elif line_code == 'T':
+                kwargs['type'] = field_info
+            elif line_code == 'G':
+                kwargs['goal'] = field_info
+
+        if line_number is not None:
+            kwargs['line_number'] = line_number
+
+        return cls(**kwargs)
+
+    @classmethod
+    def from_string(cls, string, separator='\n', line_number=None):
+        """Return a class instance from a QIF file section string.
+
+        Parameters
+        ----------
+        string : str
+            The string containing the QIF-formatted data.
+        separator : str, default='\n'
+             The line separator for the QIF file. This probably won't need changing.
+        line_number : int, default=None
+            The line number of the header line of the investment in the QIF file.
+
+        Returns
+        -------
+        Security
+            A Security object created from the QIF strings.
+        """
+        property_list = string.split(separator)
+        return cls.from_list(property_list, line_number)
+
+    def to_dict(self, ignore=None):
+        """Return a dict object representing the Security.
+
+        Parameters
+        ----------
+        ignore : list of str, default=None
+             A list of strings of parameters that should be excluded from the dict.
+
+        Returns
+        -------
+        dict
+            A dict representing the Investment object.
+        """
+
+        if ignore is None:
+            ignore = []
+
+        res = {key.strip('_'): value for (key, value) in self.__dict__.items()
+               if value is not None and key.strip('_') not in ignore}
+
+        return res

--- a/tests/test_qif.py
+++ b/tests/test_qif.py
@@ -7,7 +7,6 @@ from quiffen.core.categories_classes import Category, Class
 from quiffen.core.qif import Qif
 from quiffen.core.transactions import Transaction
 
-
 class TestQif(TestCase):
 
     def test_read_qif(self):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,89 @@
+from unittest import TestCase
+from quiffen.core.security import Security
+from quiffen.core.qif import Qif
+
+class TestSecurity(TestCase):
+
+    # exercise the Security class
+
+    def test_equality(self):
+
+        S1 = Security('Test','TEST','Stock','Growth')
+        S2 = Security('Test','TEST','Stock','Growth')
+        S3 = Security('Test','TEST','Stock','Other')
+
+        self.assertEqual(S1,S2)
+        self.assertNotEqual(S1,S3)
+
+    def test_str(self):
+        S1 = Security('Test','TEST','Stock','Growth')
+        print(S1)
+
+    def test_repr(self):
+        S1 = Security('Test','TEST','Stock','Growth')
+        print(repr(S1))
+
+    def test_from_list(self):
+        lst = ['NTest','STEST','TStock','GGrowth']
+        Slst = Security.from_list(lst)
+        S1 = Security('Test','TEST','Stock','Growth')
+        self.assertEqual(S1,Slst)
+
+    def test_from_string(self):
+        S1 = Security('Test','TEST','Stock','Growth')
+        string1 = 'NTest\nSTEST\nTStock\nGGrowth'
+        string2 = 'NTest_STEST_TStock_GGrowth'
+
+        Ss1 = Security.from_string(string1)
+        Ss2 = Security.from_string(string2, separator='_')
+
+        self.assertEqual(S1,Ss1)
+        self.assertEqual(Ss1,Ss2)
+    
+    def test_to_dict(self):
+        S1 = Security('Test','TEST','Stock','Growth')
+        expected = {'name': 'Test', 'symbol': 'TEST', 'type':'Stock', 'goal':'Growth'}
+        self.assertEqual(S1.to_dict(), expected)
+
+class TestQifSecurity(TestCase):
+    # read in the test qif and make sure it has what we think it should have
+
+    def test_reader(self):
+        qif = Qif.parse('testqifs/example-security-list.qif')
+        self.assertEqual(len(qif.securities),3)
+        self.assertEqual(qif.securities['Security1'].symbol,'USD0000')
+        self.assertEqual(qif.securities['Security2'].symbol,'G002864')
+        self.assertEqual(qif.securities['Security3'].symbol,'M039728')
+        self.assertNotEqual(qif.securities['Security3'].symbol,'M039728xxxxxxx')
+        self.assertEqual(qif.securities['Security3'].goal,'Growth')
+        self.assertEqual(qif.securities['Security3'].type,'Stock')
+        self.assertEqual(qif.securities['Security2'].goal,'Growth')
+        self.assertEqual(qif.securities['Security2'].type,'Stock')
+        self.assertEqual(qif.securities['Security1'].goal,'Growth')
+        self.assertEqual(qif.securities['Security1'].type,'Stock')
+
+    def test_from_to_qif(self):
+        qif = Qif.parse('testqifs/example-security-list.qif')
+        qif.to_qif('testqifs/example-security-list.write.qif')
+
+        qif2 = Qif.parse('testqifs/example-security-list.write.qif')
+        self.assertEqual(qif, qif2)
+        self.assertEqual(len(qif2.securities),3)
+
+    def test_add_remove_security(self):
+        qif = Qif()
+        security = Security(name='Test')
+
+        qif.add_security(security)
+        self.assertEqual(qif, Qif(securities={'Test': Security(name='Test')}))
+
+        qif.remove_security('Test')
+        self.assertEqual(qif, Qif())
+
+    def test_to_dicts(self):
+        qif = Qif()
+        security = Security(name="Test")
+        qif.add_security(security)
+
+        sec_dict = qif.to_dicts(data='securities')
+        self.assertEqual(sec_dict,[{'name': 'Test'}])

--- a/tests/testqifs/example-security-list.qif
+++ b/tests/testqifs/example-security-list.qif
@@ -1,0 +1,16 @@
+!Type:Security
+NSecurity1
+SUSD0000
+TStock
+GGrowth
+^
+NSecurity2
+SG002864
+TStock
+GGrowth
+^
+NSecurity3
+SM039728
+TStock
+GGrowth
+^


### PR DESCRIPTION
Issue #30 relates to qifs with a list of Security objects in them. At the moment Quiffen is simply not aware of this class at all. It is relatively simple with only four string members, so I added it and tested that it works OK. 

Potential warts:

* Documentation is thin for this. I found a[ google groups post from twenty years ago](https://groups.google.com/g/alt.comp.software.financial.quicken/c/Nh5D73q-bEg) referencing stuff from Quicken's developer from the nineties.
* The documentation implies yet another list type, that of security prices. I can't find a complete example qif of this at all so I don't really know what format it comes in. 
* The [Haskell docs for SecurityType](https://hackage.haskell.org/package/qif-1.1.1/docs/Data-QIF.html) imply the security type field is an enum. I can't find another reference for this. For now it is just a string and I don't validate against this list. I imagine software which consumes qifs will let you know if it doesn't like the type.
* Potential for the security's goal to be an enum as well if it selected from a drop down or similar. Again allowed anything in the string
* Haven't allowed for security name being blank / non present (use 'Security' + line number as a default? or just fail?)