### PR TITLE
Fix issue 37

### DIFF
--- a/tests/test_category.py
+++ b/tests/test_category.py
@@ -909,3 +909,27 @@ def test_categories_do_not_override_each_other():
         'Food Budget',
         'Gousto',
     ]
+
+
+def test_child_categories_inherit_category_type():
+    """Test that child categories inherit the category type of their parent.
+
+    Related to issue #37.
+    https://github.com/isaacharrisholt/quiffen/issues/37
+    """
+    test_file = (
+        Path(__file__).parent / 'test_files' / 'test_category_inherit.qif'
+    )
+
+    qif = Qif.parse(test_file)
+
+    assert len(qif.categories) == 1
+
+    root = qif.categories['Root']
+    assert root.name == 'Root'
+    assert root.category_type == CategoryType.INCOME
+    assert len(root.children) == 1
+
+    child = root.children[0]
+    assert child.name == 'Child'
+    assert child.category_type == CategoryType.INCOME

--- a/tests/test_files/test_category_inherit.qif
+++ b/tests/test_files/test_category_inherit.qif
@@ -1,0 +1,14 @@
+!Account
+NMy Bank Account
+D
+TBank
+^
+!Type:Cat
+NRoot
+D
+I
+^
+NRoot:Child
+D
+I
+^


### PR DESCRIPTION
Fixes #37 

The problem was caused because the temporary category created during category parsing was left as a child of the new category's parent.