### PR TITLE
Split amounts should use '$' for their line code

### DIFF
--- a/quiffen/core/split.py
+++ b/quiffen/core/split.py
@@ -98,7 +98,7 @@ class Split(BaseModel):
         if self.date:
             qif += f'D{self.date.strftime(date_format)}\n'
         if self.amount:
-            qif += f'T{self.amount}\n'
+            qif += f'${self.amount}\n'
         if self.memo:
             qif += f'E{self.memo}\n'
         if self.cleared:

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -63,7 +63,7 @@ def test_to_qif():
     split = Split(amount=100, memo='Test Memo')
     assert split.to_qif() == (
         'S\n'
-        'T100\n'
+        '$100\n'
         'ETest Memo\n'
     )
 
@@ -83,7 +83,7 @@ def test_to_qif():
     assert split2.to_qif() == (
         'STest Category\n'
         'D2019-01-01\n'
-        'T100\n'
+        '$100\n'
         'ETest Memo\n'
         'CTrue\n'
         'L[Test Account]\n'

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -477,10 +477,10 @@ def test_to_qif_with_splits_no_classes():
         'LTest Category\n'
         'N1\n'
         'STest Split Category\n'
-        'T100\n'
+        '$100\n'
         'ETest Memo\n'
         'S\n'
-        'T200\n'
+        '$200\n'
         'ETest Memo 2\n'
     )
 
@@ -523,10 +523,10 @@ def test_to_qif_with_splits_with_classes():
         'LTest Parent:Test Child/Test Class\n'
         'N1\n'
         'STest Split Category/Test Class\n'
-        'T100\n'
+        '$100\n'
         'ETest Memo\n'
         'S\n'
-        'T200\n'
+        '$200\n'
         'ETest Memo 2\n'
     )
 
@@ -604,7 +604,7 @@ def test_from_list_with_splits_no_classes():
         'LTest Category',  # No brackets denote category
         'STest Split Category 1',
         'ETest Split Memo',
-        'T100',
+        '$100',
         'STest Split Category 2',
         'EMemo',
         '$100',


### PR DESCRIPTION
I'm trying to generate QIF files to import into GnuCash and found two issues that made this process a little bumpy. This is one of them.

With the current QIF formatting of splits, GnuCash will ignore the splits. Comparing the files that qiffen generates with other example files I found on the internet where GnuCash imports splits correctly, I noticed that qiffen writes split amounts using a line code of `T`, which is the line code for the amount of the overall transaction. Using a `$` line code instead makes it work in GnuCash.

Judging by e.g. https://en.wikipedia.org/wiki/Quicken_Interchange_Format, I think GnuCash is in the right here, and qiffen should in fact be using a line code of `$` instead of `T`.

Hence this PR! :) Let me know if there's anything else you'd like me to do!