### PR TITLE
Write some fewer empty records

### DIFF
--- a/quiffen/core/qif.py
+++ b/quiffen/core/qif.py
@@ -356,20 +356,23 @@ class Qif(BaseModel):
         """Convert the Qif object to a QIF file"""
         qif = ''
 
-        qif += '^\n'.join(
-            category.to_qif()
-            for category in self.categories.values()
-        ) + '^\n'
+        if self.categories:
+            qif += '^\n'.join(
+                category.to_qif()
+                for category in self.categories.values()
+            ) + '^\n'
 
-        qif += '^\n'.join(
-            cls.to_qif()
-            for cls in self.classes.values()
-        ) + '^\n'
+        if self.classes:
+            qif += '^\n'.join(
+                cls.to_qif()
+                for cls in self.classes.values()
+            ) + '^\n'
 
-        qif += '^\n'.join(
-            account.to_qif(date_format=date_format, classes=self.classes)
-            for account in self.accounts.values()
-        ) + '^\n'
+        if self.accounts:
+            qif += '^\n'.join(
+                account.to_qif(date_format=date_format, classes=self.classes)
+                for account in self.accounts.values()
+            ) + '^\n'
 
         if path:
             Path(path).write_text(qif, encoding='utf-8')

--- a/tests/test_qif.py
+++ b/tests/test_qif.py
@@ -1080,3 +1080,8 @@ def test_transaction_before_account_definition_2(qif_file):
 
     assert len(acc.transactions) == 1
     assert len(acc.transactions['Bank']) == 2
+
+
+def test_empty_qif():
+    qif = Qif()
+    assert qif.to_qif() == ''


### PR DESCRIPTION
I'm trying to generate QIF files to import into GnuCash and found two issues that made this process a little bumpy. This is one of them.

GnuCash was crashing on some of the QIF files that I created but didn't spit out any useful (to me, anyway) error messages.

Looking at the generated QIF in more detail, I noticed that there were instances of consecutive lines each consisting of just the `^`, indicating the end/beginning of a record, i.e. there were empty records.

One could say GnuCash should simply skip over those, but I think there's no reason why quiffen should write empty records. So if there's a chance for us to write records here that will be accepted by more software such as GnuCash, I think we should do that! 😊

It turns out that if there are no accounts, categories or classes, then code like this:
```
qif += '^\n'.join(
            cls.to_qif()
            for cls in self.classes.values()
        ) + '^\n'
```
will always result in *at least* the trailing `^\n`, without actually having written any records. This results in an empty record if there were e.g. no classes to write.

I hope you will accept this PR! :) Let me know if there's anything else you'd like me to do!