### PR TITLE
Add missing 'name' keyword argument name to some documented function calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,10 +69,10 @@ And here's an example of creating a QIF structure and exporting to a QIF file:
 >>> import quiffen
 >>> from datetime import datetime
 >>> qif = quiffen.Qif()
->>> acc = quiffen.Account('Personal Bank Account', desc='My personal bank account with Barclays.')
+>>> acc = quiffen.Account(name='Personal Bank Account', desc='My personal bank account with Barclays.')
 >>> qif.add_account(acc)
->>> groceries = quiffen.Category('Groceries')
->>> essentials = quiffen.Category('Essentials')
+>>> groceries = quiffen.Category(name='Groceries')
+>>> essentials = quiffen.Category(name='Essentials')
 >>> groceries.add_child(essentials)
 >>> qif.add_category(groceries)
 >>> tr = quiffen.Transaction(date=datetime.now(), amount=150.0)

--- a/quiffen/core/category.py
+++ b/quiffen/core/category.py
@@ -48,16 +48,16 @@ class Category(BaseModel):
     Creating a category tree, then rendering it to console.
 
     >>> import quiffen
-    >>> food = quiffen.Category('Food')
+    >>> food = quiffen.Category(name='Food')
     >>> food
     Category(name='Food', expense=True, hierarchy='Food')
-    >>> essentials = quiffen.Category('Essentials')
+    >>> essentials = quiffen.Category(name='Essentials')
     >>> food.add_child(essentials)
-    >>> pastas = quiffen.Category('Pastas')
+    >>> pastas = quiffen.Category(name='Pastas')
     >>> essentials.add_child(pastas)
     >>> pastas.hierarchy
     'Food:Essentials:Pastas'
-    >>> meat = quiffen.Category('Meat')
+    >>> meat = quiffen.Category(name='Meat')
     >>> food.add_child(meat)
     >>> print(food.render_tree())
     Food (root)


### PR DESCRIPTION
There are a few instances of `Account(...)` and `Category(...)` instantiations in the docs where the first argument is passed positionally, even though those functions don't take any positional arguments.

I.e. trying to instantiate `Account('foo')` or `Category(foo)` equally results in an error like this being thrown:

```
TypeError: __init__() takes exactly 1 positional argument (2 given)
```

This fixes those instances.