### PR TITLE
Bug fix for transaction parsing enums with trailing whitespace.

### DIFF
--- a/quiffen/core/qif.py
+++ b/quiffen/core/qif.py
@@ -272,7 +272,7 @@ class Qif(BaseModel):
 
                 accounts[last_account].add_transaction(
                     new_transaction,
-                    AccountType(header_line.split(":")[1]),
+                    AccountType(header_line.split(":")[1].strip()),
                 )
 
                 if new_transaction.category:


### PR DESCRIPTION
For some unknown reason, my QIF file seems to append a whitespace after the `Bank ` header of the transaction resulting in the following error.
```
  File "C:\Users\Apex\Desktop\Quicken\run.py", line 3, in <module>
    qif = Qif.parse('quicken.qif')
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Apex\AppData\Local\Programs\Python\Python311\Lib\site-packages\quiffen\core\qif.py", line 275, in parse
    AccountType(header_line.split(":")[1]),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Apex\AppData\Local\Programs\Python\Python311\Lib\enum.py", line 717, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Apex\AppData\Local\Programs\Python\Python311\Lib\enum.py", line 1133, in __new__
    raise ve_exc
ValueError: 'Bank ' is not a valid AccountType
```

I was able to resolve this issue by stripping whitespace.