### PR TITLE
Ignore !Option lines

### DIFF
--- a/quiffen/core/qif.py
+++ b/quiffen/core/qif.py
@@ -161,10 +161,12 @@ class Qif(BaseModel):
 
             # Allow for comments and blank lines at the top of sections
             # Also skip `!Clear:` lines to ignore flags such as `!Clear:AutoSwitch`
+            # Also skip `!Option:` lines to ignore flags such as `!Option:AutoSwitch`
             for i, line in enumerate(section_lines):
                 if (
                     not line.strip()
                     or line.strip().startswith("!Clear:")
+                    or line.strip().startswith("!Option:")
                     or line[0] == "#"
                 ):
                     continue

--- a/tests/test_files/test_option_autoswitch.qif
+++ b/tests/test_files/test_option_autoswitch.qif
@@ -1,0 +1,12 @@
+!Option:AutoSwitch
+!Account
+NMy Bank Account
+D
+TBank
+^
+!Clear:AutoSwitch
+!Option:AutoSwitch
+!Account
+NMy Bank Account
+TBank
+^

--- a/tests/test_qif.py
+++ b/tests/test_qif.py
@@ -1125,7 +1125,7 @@ def test_clear_autoswitch_ignored(qif_file_with_clear_autoswitch):
 
 
 def test_option_autoswitch_ignored(qif_file_with_option_autoswitch):
-    """Tests that `!Clear:OpitonSwitch` flag exported by Quicken
+    """Tests that `!Opiton:AutoSwitch` flag exported by Quicken
     is ignored.
 
     Relates to discussion #92.

--- a/tests/test_qif.py
+++ b/tests/test_qif.py
@@ -44,6 +44,11 @@ def qif_file_with_clear_autoswitch():
     return Path(__file__).parent / "test_files" / "test_clear_autoswitch.qif"
 
 
+@pytest.fixture
+def qif_file_with_option_autoswitch():
+    return Path(__file__).parent / "test_files" / "test_option_autoswitch.qif"
+
+
 def test_create_qif():
     """Test creating a Qif instance"""
     qif = Qif()
@@ -1115,5 +1120,16 @@ def test_clear_autoswitch_ignored(qif_file_with_clear_autoswitch):
     Relates to discussion #89.
     """
     qif = Qif.parse(qif_file_with_clear_autoswitch)
+    assert len(qif.accounts) == 1
+    assert list(qif.accounts.keys()) == ["My Bank Account"]
+
+
+def test_option_autoswitch_ignored(qif_file_with_option_autoswitch):
+    """Tests that `!Clear:OpitonSwitch` flag exported by Quicken
+    is ignored.
+
+    Relates to discussion #92.
+    """
+    qif = Qif.parse(qif_file_with_option_autoswitch)
     assert len(qif.accounts) == 1
     assert list(qif.accounts.keys()) == ["My Bank Account"]


### PR DESCRIPTION
Similar to #89, Quicken QIF exports (sometimes?) include `!Option:AutoSwitch` sections. The proposed solution simply ignores those lines just like the `!Clear` lines are are ignored as of that PR.

As I mentioned in #92, I have a suspicion that everything between the two `!Option:AutoSwitch` lines could be ignored, but this seems to work for me for now.

I added a test case, but I'm not sure how this would fit into your release process so I didn't make any changes to the revision. Please let me know if you have any thoughts or if there's anything else I can do.