### PR TITLE
Handle unknown accounts and split transfers

### DIFF
--- a/quiffen/core/account.py
+++ b/quiffen/core/account.py
@@ -252,7 +252,7 @@ class Account(BaseModel):
             elif line_code == "D":
                 kwargs["desc"] = field_info
             elif line_code == "T":
-                if field_info in AccountType:
+                if field_info in [item.value for item in AccountType]:
                     kwargs["account_type"] = field_info
                 else:
                     kwargs["account_type"] = AccountType.UNKNOWN.value

--- a/quiffen/core/account.py
+++ b/quiffen/core/account.py
@@ -255,7 +255,7 @@ class Account(BaseModel):
                 if field_info in AccountType:
                     kwargs["account_type"] = field_info
                 else:
-                    kwargs["account_type"] = "Unknown"
+                    kwargs["account_type"] = AccountType.UNKNOWN.value
             elif line_code == "L":
                 kwargs["credit_limit"] = field_info.replace(",", "")
             elif line_code in {"$", "£"}:

--- a/quiffen/core/account.py
+++ b/quiffen/core/account.py
@@ -21,6 +21,7 @@ class AccountType(str, Enum):
     OTH_L = "Oth L"
     INVOICE = "Invoice"
     INVST = "Invst"
+    UNKNOWN = "Unknown"
 
 
 class Account(BaseModel):
@@ -251,7 +252,10 @@ class Account(BaseModel):
             elif line_code == "D":
                 kwargs["desc"] = field_info
             elif line_code == "T":
-                kwargs["account_type"] = field_info
+                if field_info in AccountType:
+                    kwargs["account_type"] = field_info
+                else:
+                    kwargs["account_type"] = "Unknown"
             elif line_code == "L":
                 kwargs["credit_limit"] = field_info.replace(",", "")
             elif line_code in {"$", "£"}:

--- a/quiffen/core/transaction.py
+++ b/quiffen/core/transaction.py
@@ -369,8 +369,11 @@ class Transaction(BaseModel):
                     classes,
                 )
 
-                split_category = create_categories_from_hierarchy(field_info)
-                new_split = Split(category=split_category)
+                if field_info.startswith("["):
+                    new_split = Split(to_account=field_info[1:-1])
+                else:
+                    split_category = create_categories_from_hierarchy(field_info)
+                    new_split = Split(category=split_category)
                 splits.append(new_split)
                 current_split = new_split
             elif line_code == "D":

--- a/tests/test_files/test_split.qif
+++ b/tests/test_files/test_split.qif
@@ -1,0 +1,11 @@
+!Type:Bank
+D1/ 1'00
+U-10.00
+T-10.00
+PA Payee
+L--Split--
+S[An Account]
+$-9.00
+SA Category
+$-1.00
+^

--- a/tests/test_files/test_unknown_account_type.qif
+++ b/tests/test_files/test_unknown_account_type.qif
@@ -1,0 +1,26 @@
+# This is a strange file but it is representative of a real Quicken
+# export. It's unclear what the purpose of the !Option section is.
+# But it seems like non-standard account types are used in this section,
+# even though when the account transactions appear, they use a standard
+# type (Invst). Since the meaning is unclear we take the simplest
+# approach. The first time !Account is encountered, that is where
+# the account is defined. If the account type is unknown it will
+# be identified as such. In this case, the transactions may be
+# categorized under a different account type, which isn't ideal but
+# the QIF standard seems to allow for this.
+!Option:AutoSwitch
+!Account
+^
+NPortfolio Account
+TPort
+^
+!Clear:AutoSwitch
+!Account
+NPortfolio Account
+TInvst
+^
+!Type:Invst
+D1/ 1'01
+NCash
+L[Portfolio Account]
+^

--- a/tests/test_qif.py
+++ b/tests/test_qif.py
@@ -50,13 +50,13 @@ def qif_file_with_option_autoswitch():
 
 
 @pytest.fixture
-def qif_file_with_unknown_account_type():
-    return Path(__file__).parent / "test_files" / "test_unknown_account_type.qif"
+def qif_file_with_split_to_account():
+    return Path(__file__).parent / "test_files" / "test_split.qif"
 
 
 @pytest.fixture
-def qif_file_with_split_to_account():
-    return Path(__file__).parent / "test_files" / "test_split.qif"
+def qif_file_with_unknown_account_type():
+    return Path(__file__).parent / "test_files" / "test_unknown_account_type.qif"
 
 
 def test_create_qif():
@@ -1145,20 +1145,11 @@ def test_option_autoswitch_ignored(qif_file_with_option_autoswitch):
     assert list(qif.accounts.keys()) == ["My Bank Account"]
 
 
-def test_unknown_account_type(qif_file_with_unknown_account_type):
-    """Tests that unknown account types are handled.
-
-    Relates to discussion #95.
-    """
-    qif = Qif.parse(qif_file_with_unknown_account_type)
-    assert qif.accounts["Portfolio Account"].account_type == AccountType.UNKNOWN
-    # Oddly, the transactions are grouped under a known account type.
-    transactions = qif.accounts["Portfolio Account"].transactions
-    assert AccountType.INVST in transactions
-
-
 def test_split_to_account(qif_file_with_split_to_account):
-    """Tests that a split to an account is recorded appropriately,"""
+    """Tests that a split to an account is recorded appropriately.
+
+    Relates to discussion #94
+    """
     qif = Qif.parse(qif_file_with_split_to_account)
     account = qif.accounts["Quiffen Default Account"]
 
@@ -1172,3 +1163,15 @@ def test_split_to_account(qif_file_with_split_to_account):
     assert split_transaction.splits[0].category is None
     assert split_transaction.splits[1].to_account is None
     assert split_transaction.splits[1].category == Category(name="A Category")
+
+
+def test_unknown_account_type(qif_file_with_unknown_account_type):
+    """Tests that unknown account types are handled.
+
+    Relates to discussion #95.
+    """
+    qif = Qif.parse(qif_file_with_unknown_account_type)
+    assert qif.accounts["Portfolio Account"].account_type == AccountType.UNKNOWN
+    # Oddly, the transactions are grouped under a known account type.
+    transactions = qif.accounts["Portfolio Account"].transactions
+    assert AccountType.INVST in transactions

--- a/tests/test_qif.py
+++ b/tests/test_qif.py
@@ -49,6 +49,11 @@ def qif_file_with_option_autoswitch():
     return Path(__file__).parent / "test_files" / "test_option_autoswitch.qif"
 
 
+@pytest.fixture
+def qif_file_with_unknown_account_type():
+    return Path(__file__).parent / "test_files" / "test_unknown_account_type.qif"
+
+
 def test_create_qif():
     """Test creating a Qif instance"""
     qif = Qif()
@@ -1133,3 +1138,15 @@ def test_option_autoswitch_ignored(qif_file_with_option_autoswitch):
     qif = Qif.parse(qif_file_with_option_autoswitch)
     assert len(qif.accounts) == 1
     assert list(qif.accounts.keys()) == ["My Bank Account"]
+
+
+def test_unknown_account_type(qif_file_with_unknown_account_type):
+    """Tests that unknown account types are handled.
+
+    Relates to discussion #95.
+    """
+    qif = Qif.parse(qif_file_with_unknown_account_type)
+    assert qif.accounts["Portfolio Account"].account_type == AccountType.UNKNOWN
+    # Oddly, the transactions are grouped under a known account type.
+    transactions = qif.accounts["Portfolio Account"].transactions
+    assert AccountType.INVST in transactions


### PR DESCRIPTION
This PR addresses two issues:

- #94
- #95

## Split Transfers
Issue #95 is fairly straightforward. We just need to detect and handle transfers in split transactions. This means that when a split transaction category is in brackets (e.g. `[Savings]`), this value should be assigned to `Split.to_account` rather than `Split.category`. See the associated issue for more detail.

## Unknown Account Types
Issue #94 is a bit more tricky. I think this situation relates to the `!Option:AutoSwitch` section of the QIF file that isn't well defined. The associated issue has more detail, but in summary: sometimes accounts have types that aren't defined in the `AccountType` enum. To handle this situation, a fallback mechanism is implemented that assigns these accounts an 'unknown' type, ensuring the parser remains functional when this situation is encountered. It doesn't seem ideal, and perhaps we'll find a better solution in the future. But this addresses pydantic failures when reading files with these unknown account types. It is left to the user to detect and fix the unknown types on their end if they desire.