### PR TITLE
Add `parse_string` function to `Qif` class

### DIFF
--- a/quiffen/core/qif.py
+++ b/quiffen/core/qif.py
@@ -137,6 +137,32 @@ class Qif(BaseModel):
         if not data:
             raise ParserException("The file is empty.")
 
+        return cls.parse_string(data, separator=separator, day_first=day_first)
+
+    @classmethod
+    def parse_string(
+        cls, data: str, separator: str = "\n", day_first: bool = False
+    ) -> Qif:
+        """Return a class instance from a string containing QIF data.
+
+        Parameters
+        ----------
+        data : str
+            The string of QIF data
+        separator : str, default='\n'
+            The line separator for the QIF file. This probably won't need
+            changing.
+        day_first : bool, default=False
+            Whether the day or month comes first in the date.
+
+        Returns
+        -------
+        Qif
+            A Qif object containing all the data in the QIF file.
+        """
+        if not data:
+            raise ParserException("The file is empty.")
+
         accounts: Dict[str, Account] = {}
         last_account = None
         categories: Dict[str, Category] = {}

--- a/quiffen/core/qif.py
+++ b/quiffen/core/qif.py
@@ -161,7 +161,7 @@ class Qif(BaseModel):
             A Qif object containing all the data in the QIF file.
         """
         if not data:
-            raise ParserException("The file is empty.")
+            raise ParserException("The data string is empty.")
 
         accounts: Dict[str, Account] = {}
         last_account = None

--- a/tests/test_qif.py
+++ b/tests/test_qif.py
@@ -217,12 +217,33 @@ def test_from_list():
         qif.from_list([])
 
 
-def test_parse_works(qif_file):
+def test_parse_string_works():
+    """Test parsing a QIF file"""
+    qif_string = (
+        "!Type:Class\n"
+        "NTest class\n"
+        "DThis is just a class I added here for test purposes\n"
+        "^\n"
+        "!Type:Class\n"
+        "NTest class 2\n"
+        "DThis is just a class I added here for test purposes\n"
+        "^\n"
+    )
+    Qif.parse_string(qif_string)
+
+
+def test_parse_empty_string():
+    """Test parsing an empty QIF file"""
+    with pytest.raises(ParserException):
+        Qif.parse("")
+
+
+def test_parse_file_works(qif_file):
     """Test parsing a QIF file"""
     Qif.parse(qif_file)
 
 
-def test_parse_works_with_oth_a_account(qif_file_with_oth_a_account):
+def test_parse_file_works_with_oth_a_account(qif_file_with_oth_a_account):
     """Test parsing a QIF file with an OTH account"""
     Qif.parse(qif_file_with_oth_a_account)
 


### PR DESCRIPTION
Extends the `Qif` class to allow qif files to be passed in as strings (I.e. when parsing files through an API)
`parse` has been updated to read the file and then call `parse_string` so all previous tests are still checking the whole code base. Appropriate tests have been added to test the `parse_string` alone.

Addresses #107 