### PR TITLE
Ignore X line codes

### DIFF
--- a/quiffen/core/transaction.py
+++ b/quiffen/core/transaction.py
@@ -480,6 +480,9 @@ class Transaction(BaseModel):
                 kwargs["current_loan_balance"] = field_info.replace(",", "")
             elif line_code == "7":
                 kwargs["original_loan_amount"] = field_info.replace(",", "")
+            elif line_code == "X":
+                # Ignore X line code used for invoices in Quicken business versions 
+                pass
             else:
                 raise ValueError(f"Unknown line code: {line_code}")
 


### PR DESCRIPTION
The business versions of Quicken use line codes beginning with 'X' for things like invoices. Parsing a .qif file containing these 'X' line codes would result in an exception being raised. This change just ignores those X line codes and allows these files to be parsed.
Fixes issue #112.